### PR TITLE
Specify directories in grafana config file

### DIFF
--- a/provisioning/monitor/config/grafana.ini
+++ b/provisioning/monitor/config/grafana.ini
@@ -12,16 +12,16 @@
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
-;data = /var/lib/grafana
+data = /var/lib/grafana
 
 # Directory where grafana can store logs
-;logs = /var/log/grafana
+logs = /var/log/grafana
 
 # Directory where grafana will automatically scan and look for plugins
-;plugins = /var/lib/grafana/plugins
+plugins = /var/lib/grafana/plugins
 
 # folder that contains provisioning config files that grafana will apply on startup and while running.
-;provisioning = conf/provisioning
+provisioning = /etc/grafana/provisioning
 
 #################################### Server ####################################
 [server]


### PR DESCRIPTION
Without doing this, the grafana-cli utility has a hard time doing administrative actions. In particular, 'grafana-cli admin reset-admin-password' needs to know the provisioning and data directories. This command is the only way to reset the admin password if it has been lost, so it's a pretty important one.

I manually changed the /etc/grafana/grafana.ini file on monitor.alerts.ztf.uw.edu to match this. I don't think it's necessary to apply a terraform change after merging this.