### PR TITLE
Raise file descriptor limits for broker services

### DIFF
--- a/provisioning/broker/config/ztf-kafka.service
+++ b/provisioning/broker/config/ztf-kafka.service
@@ -14,6 +14,7 @@ Restart=always
 SuccessExitStatus=143
 RestartSec=60
 SyslogIdentifier=ztf-kafka
+LimitNOFILE=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/provisioning/broker/config/ztf-mirrormaker.service
+++ b/provisioning/broker/config/ztf-mirrormaker.service
@@ -16,6 +16,7 @@ Restart=always
 SuccessExitStatus=143
 RestartSec=60
 SyslogIdentifier=ztf-mirrormaker
+LimitNOFILE=10000
 
 [Install]
 WantedBy=multi-user.target

--- a/provisioning/broker/config/ztf-zookeeper.service
+++ b/provisioning/broker/config/ztf-zookeeper.service
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/zookeeper-server-start /etc/kafka/zookeeper.properties
 TimeoutStopSec=180
 Restart=no
 SyslogIdentifier=ztf-zookeeper
+LimitNOFILE=10000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Kafka Brokers want a *lot* of open files. Confluent recommends setting the limit to at least 100,000, but the default is a paltry 4096.

We can raise this by setting LimitNOFILE in the systemd unit files for broker services. This corresponds to setting 'ulimit -n', as per 'man systemd.exec'.

Mirrormaker and ZooKeeper get 10,000 files, which should be plenty. Kafka gets no limit because we are OK with it being greedy.